### PR TITLE
Change httpsnippet dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
   },
   "dependencies": {
-    "httpsnippet": "^1.16.7",
+    "httpsnippet": "github:confluentinc/httpsnippet#decode-url",
     "openapi-sampler": "^1.0.0-beta.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
   },
   "dependencies": {
-    "httpsnippet": "github:confluentinc/httpsnippet#decode-url",
+    "httpsnippet": "github:confluentinc/httpsnippet#master",
     "openapi-sampler": "^1.0.0-beta.14"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
   },
   "dependencies": {
-    "httpsnippet": "github:confluentinc/httpsnippet#master",
+    "httpsnippet": "github:confluentinc/httpsnippet#not-encode-url",
     "openapi-sampler": "^1.0.0-beta.14"
   },
   "devDependencies": {


### PR DESCRIPTION
the origin httpsnippet does not support placeholder like {id}, it will be encoded in percentage like %7Bid%7D, which is not friendly to our user