### PR TITLE
API-808: Add parameter to enable decode url for placeholder

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ const getEndpointSnippets = function (openApi, path, method, targets, values) {
  * @param {array} targets   List of languages to create snippets in, e.g,
  *                          ['cURL', 'Node']
  */
-const getSnippets = function (openApi, targets) {
+const getSnippets = function (openApi, targets, encodeUri = true) {
   const harList = OpenAPIToHar.getAll(openApi);
 
   const results = [];
@@ -70,6 +70,12 @@ const getSnippets = function (openApi, targets) {
     // create HTTPSnippet object:
     const har = harList[i];
     const snippet = new HTTPSnippet(har.har);
+
+    if (!encodeUri) {
+      snippet.requests.map(request => {
+        return uriDecodeRequest(request);
+      })
+    }
 
     const snippets = [];
     for (let j in targets) {
@@ -146,6 +152,19 @@ const getResourceName = function (urlStr) {
     }
   }
 };
+
+/**
+ * 
+ */
+
+const uriDecodeRequest = function(request) {
+  request.fullUrl = decodeURI(request.fullUrl)
+  request.url = decodeURI(request.url)
+  request.uriObj.path = decodeURI(request.uriObj.path)
+  request.uriObj.pathname = decodeURI(request.uriObj.pathname)
+  request.uriObj.href = decodeURI(request.uriObj.href)
+  return request;
+}
 
 /**
  * Format the given target by splitting up language and library and making sure

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const HTTPSnippet = require('httpsnippet');
  *                          ['cURL', 'Node']
  * @param {object} values   Optional: Values for the query parameters if present
  */
-const getEndpointSnippets = function (openApi, path, method, targets, values) {
+const getEndpointSnippets = function (openApi, path, method, targets, values, encodeUri = true) {
   // if optional parameter is not provided, set it to empty object
   if (typeof values === 'undefined') {
     values = {};
@@ -31,6 +31,12 @@ const getEndpointSnippets = function (openApi, path, method, targets, values) {
   const har = OpenAPIToHar.getEndpoint(openApi, path, method, values);
 
   const snippet = new HTTPSnippet(har);
+
+  if (!encodeUri) {
+    snippet.requests.map(request => {
+      return uriDecodeRequest(request);
+    })
+  }
 
   const snippets = [];
   for (let j in targets) {

--- a/index.js
+++ b/index.js
@@ -154,7 +154,9 @@ const getResourceName = function (urlStr) {
 };
 
 /**
- * 
+ * Decoding the encoded uri received from HTTP Snippet. So that when sample code snippets are  
+ * generated we won't see encoded url.
+ * Eg. ../request/%7Bid%7D --> ../request/{id}
  */
 
 const uriDecodeRequest = function(request) {

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,56 @@ const PetStoreOpenAPI3 = require('./petstore_oas.json');
 const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
 
+test('Placeholder in the url is encoded when the flag is enabled', function(t){
+  const result = OpenAPISnippets.getSnippets(InstagramOpenAPI, ['c_libcurl']);
+  result.forEach(r => {
+    r.snippets.forEach(s => {
+      t.true(s.content.includes(encodeURI(r.url)));
+    });
+  });
+  t.end();
+});
+
+test('Placeholder in the url is not encoded when the flag is disabled', function(t){
+  const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['c_libcurl'], false);
+  result.forEach(r => {
+    r.snippets.forEach(s => {
+      t.true(s.content.includes(decodeURI(r.url)));
+    });
+  });
+  t.end();
+});
+
+test('Placeholder in the url is encoded when the flag is enabled', function(t){
+  const result = OpenAPISnippets.getEndpointSnippets(
+    BloggerOpenAPI,
+    '/blogs/{blogId}/pages',
+    'post',
+    ['node_request']
+  );
+  result.snippets.forEach(s => {
+      t.true(s.content.includes(encodeURI(result.url)));
+    });
+  t.end();
+});
+
+test('Placeholder in the url is not encoded when the flag is disabled', function(t){
+  let values;
+  const result = OpenAPISnippets.getEndpointSnippets(
+    BloggerOpenAPI,
+    '/blogs/{blogId}/pages',
+    'post',
+    ['node_request'],
+    values,
+    false
+  );
+  console.log(result);
+  result.snippets.forEach(s => {
+      t.true(s.content.includes(decodeURI(result.url)));
+    });
+  t.end();
+});
+
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
**What?**
-
- Enabling the capability to have decoded URIs as part of the snippets generated by httpSnippet.
- Eg. ../request/%7Bid%7D --> ../request/{id}.
- By default the parameter is set to "true" so it is not a breaking change.
- Ref: https://github.com/Kong/httpsnippet/pull/205 

**Test**
-
- Wrote unit tests to validate the changes.