### PR TITLE
API-808: Fix URL Encoding Issue in API Reference Docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "mkdir -p dist && browserify -g uglifyify ./index.js > ./dist/openapisnippet.min.js"
   },
   "dependencies": {
-    "httpsnippet": "github:confluentinc/httpsnippet#ff5ab7260d4787596dcca2a2b8865db515416067",
+    "httpsnippet": "github:confluentinc/httpsnippet#4aac3efb07ff2dedf09d0549dc6ba4bc5b5f4ac8",
     "openapi-sampler": "^1.0.0-beta.14",
     "openapi-snippet": "^0.14.0"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
 const FormUrlencodedExampleAPI = require('./form_urlencoded_example.json');
 
-test('Placeholder in the url is not encoded', function(t){
+test('Getting snippets, Placeholder in the url is not encoded', function(t){
   const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['c_libcurl']);
   result.forEach(r => {
     r.snippets.forEach(s => {
@@ -24,7 +24,7 @@ test('Placeholder in the url is not encoded', function(t){
   t.end();
 });
 
-test('Placeholder in the url is not encoded', function(t){
+test('Getting endpoint snippets, Placeholder in the url is not encoded', function(t){
   const result = OpenAPISnippets.getEndpointSnippets(
     BloggerOpenAPI,
     '/blogs/{blogId}/pages',

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,30 @@ const ParameterSchemaReferenceAPI = require('./parameter_schema_reference');
 const ParameterExampleReferenceAPI = require('./parameter_example_swagger.json');
 const FormUrlencodedExampleAPI = require('./form_urlencoded_example.json');
 
+test('Placeholder in the url is not encoded', function(t){
+  const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['c_libcurl']);
+  result.forEach(r => {
+    r.snippets.forEach(s => {
+      t.true(s.content.includes(decodeURI(r.url)));
+    });
+  });
+  t.end();
+});
+
+test('Placeholder in the url is not encoded', function(t){
+  const result = OpenAPISnippets.getEndpointSnippets(
+    BloggerOpenAPI,
+    '/blogs/{blogId}/pages',
+    'post',
+    ['node_request'],
+  );
+  console.log(result);
+  result.snippets.forEach(s => {
+      t.true(s.content.includes(decodeURI(result.url)));
+    });
+  t.end();
+});
+
 test('Getting snippets should not result in error or undefined', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
### What?
- The API Team uses this branch of openapi-snippet for docs generation.
- By default we are disabling URI encoding in the snippets generated so as to not render encoded URIs on the docs. Ref: https://github.com/confluentinc/httpsnippet/pull/5 
- Eg. ../request/%7Bid%7D --> ../request/{id}.
- Since this fork is only used by the API team it is not a breaking change.
### Test
- Performed local testing to validate the changes